### PR TITLE
chore: promote node-http to version 0.0.2

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: http://bucketrepo-jx.jx.local
 releases:
 - chart: dev/node-http
-  version: 0.0.1
+  version: 0.0.2
   name: node-http
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# node-http

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* v2 Cambios en charts/node-http/values.yml (Primo Ticona)
