### PR TITLE
chore: promote node-http to version 0.0.3

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: http://bucketrepo-jx.jx.local
 releases:
 - chart: dev/node-http
-  version: 0.0.2
+  version: 0.0.3
   name: node-http
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# node-http

## Changes in version 0.0.3

### Bug Fixes

* trigger publish chart node-http v0.0.3 (Primo Ticona)

### Chores

* release 0.0.3 (jenkins-x-bot)
* add variables (jenkins-x-bot)
* trigger jx release (Primo Ticona)
